### PR TITLE
support nil body

### DIFF
--- a/lib/logstash/inputs/jms.rb
+++ b/lib/logstash/inputs/jms.rb
@@ -141,8 +141,10 @@ class LogStash::Inputs::Jms < LogStash::Inputs::Threadable
             event.set(field.to_s, value) # TODO(claveau): needs codec.decode or converter.convert ?
           end
         elsif msg.java_kind_of?(JMS::TextMessage) || msg.java_kind_of?(JMS::BytesMessage)
-          @codec.decode(msg.to_s) do |event_message|
-            event = event_message
+          if !msg.to_s.nil?
+            @codec.decode(msg.to_s) do |event_message|
+              event = event_message
+            end
           end
         else
           @logger.error( "Unknown data type #{msg.data.class.to_s} in Message" )


### PR DESCRIPTION
# issues 

**When "TextMessage" or "BytesMessage" has nil body that cause exception like**

> 
19: 04: 25.975[[main] < jms]ERROR logstash.inputs.jms - Failed to create event {
	: message => Java::ComTibcoTibjms::TibjmsTextMessage: Attributes: {
		: jms_correlation_id => nil,
		: jms_delivery_mode_sym => : non_persistent,
		: jms_destination => "Queue[some.queue]",
		: jms_expiration => 0,
		: jms_message_id => "ID:EMS-SERVER.689A58124127748CC5:42091",
		: jms_priority => 4,
		: jms_redelivered => false,
		: jms_reply_to => nil,
		: jms_timestamp => 1487073865429,
		: jms_type => nil
	}
	Properties: {
		"TS" => "2017-02-14 17:56:30.661",
		"JMSXDeliveryCount" => 1,
		"TRACE" => "some text.",
		"UUID" => "99-9509d482-01c6-4d65-be9b-98432bd88a74",
		"_ns_" => "www.tibco.com/be/ontology/Events/xxx/xxx/xxx",
		"OPER_NAME" => "XXXX",
		"_nm_" => "Logger",
		"LOG_LEVEL" => "2",
		"PROC_ID" => "XXXX",
		"COM_NAME" => "XXXX"
	},
	: exception =>  #  < NoMethodError: undefined method `force_encoding' for nil:NilClass>, :backtrace=>["C:/TOOLS/logstash-5.2.0/logstash-core/lib/logstash/util/charset.rb:14:in ` convert '", "C:/TOOLS/logstash-5.2.0/vendor/bundle/jruby/1.9/gems/logstash-codec-plain-3.0.2/lib/logstash/codecs/plain.rb:35:in `decode' ", " C: /TOOLS/logstash - 5.2.0 / vendor / bundle / jruby / 1.9 / gems / logstash - input - jms - 3.0.0 - java / lib / logstash / inputs / jms.rb: 145: in `queue_event'", "C:/TOOLS/logstash-5.2.0/vendor/bundle/jruby/1.9/gems/logstash-input-jms-3.0.0-java/lib/logstash/inputs/jms.rb:190:in ` run_consumer '", "org/jruby/RubyProc.java:281:in `call' ", " C: /TOOLS/logstash - 5.2.0 / vendor / bundle / jruby / 1.9 / gems / jruby - jms - 1.2.0 - java / lib / jms / message_consumer.rb: 55: in `each'", "C:/TOOLS/logstash-5.2.0/vendor/bundle/jruby/1.9/gems/jruby-jms-1.2.0-java/lib/jms/session.rb:402:in ` consume '", "C:/TOOLS/logstash-5.2.0/vendor/bundle/jruby/1.9/gems/jruby-jms-1.2.0-java/lib/jms/session.rb:400:in `consume' ", " C: /TOOLS/logstash - 5.2.0 / vendor / bundle / jruby / 1.9 / gems / logstash - input - jms - 3.0.0 - java / lib / logstash / inputs / jms.rb: 189: in `run_consumer'", "org/jruby/RubyProc.java:281:in ` call '", "C:/TOOLS/logstash-5.2.0/vendor/bundle/jruby/1.9/gems/jruby-jms-1.2.0-java/lib/jms/connection.rb:258:in `session' ", " C: /TOOLS/logstash - 5.2.0 / vendor / bundle / jruby / 1.9 / gems / jruby - jms - 1.2.0 - java / lib / jms / connection.rb: 71: in `session'", "org/jruby/RubyProc.java:281:in ` call '", "C:/TOOLS/logstash-5.2.0/vendor/bundle/jruby/1.9/gems/jruby-jms-1.2.0-java/lib/jms/connection.rb:53:in `start' ", " C: /TOOLS/logstash - 5.2.0 / vendor / bundle / jruby / 1.9 / gems / jruby - jms - 1.2.0 - java / lib / jms / connection.rb: 70: in `session'", "C:/TOOLS/logstash-5.2.0/vendor/bundle/jruby/1.9/gems/logstash-input-jms-3.0.0-java/lib/logstash/inputs/jms.rb:186:in ` run_consumer '", "C:/TOOLS/logstash-5.2.0/vendor/bundle/jruby/1.9/gems/logstash-input-jms-3.0.0-java/lib/logstash/inputs/jms.rb:257:in `run' ", " C: /TOOLS/logstash - 5.2.0 / logstash - core / lib / logstash / pipeline.rb: 370: in `inputworker'", "C:/TOOLS/logstash-5.2.0/logstash-core/lib/logstash/pipeline.rb:364:in ` start_input '"]}
> 

# changes 
**Fix by check nil body before process, I not ruby dev not sure it appropriate, please help review thanks**
