### PR TITLE
Handle MissingConverterException errors

### DIFF
--- a/spec/inputs/unit/jms_spec.rb
+++ b/spec/inputs/unit/jms_spec.rb
@@ -199,6 +199,19 @@ describe "inputs/jms" do
     end
   end
 
+  describe '#set_field' do
+    let(:event) { LogStash::Event.new }
+    it 'should set the field correctly' do
+      plugin.set_field(event, "hello", "fff")
+      expect(event.get("hello")).to eql("fff")
+    end
+
+    it 'should set handle field values that are not convertible' do
+      plugin.set_field(event, "hello", Date.new(1999,1,1))
+      expect(event.get("hello")).to eql("1999-01-01")
+    end
+  end
+
   describe '#error_hash' do
     context 'should handle Java exceptions with a chain of causes' do
       let (:raised) { java.lang.Exception.new("Outer", java.lang.RuntimeException.new("middle", java.io.IOException.new("Inner")))}


### PR DESCRIPTION
With certain JMS providers, the JMS headers may include values that
cannot be handled and added to an event, which currently throw either
a MissingConverterException or an IllegalArgumentException. This commit
attempts to handle these errors more gracefully by calling `to_s` and
attempting to use the string representation rather than crash the plugin

