### PR TITLE
Feat: event_factory support + targets to aid ECS

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -5,7 +5,7 @@ env
 
 set -ex
 
-export ACTIVEMQ_VERSION=5.15.9
+export ACTIVEMQ_VERSION=5.15.15
 ./setup_broker.sh
 bundle install
 bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
  - Feat: event_factory support + targets to aid ECS [#49](https://github.com/logstash-plugins/logstash-input-jms/pull/49)
  - Fix: when configured to add JMS headers to the event, headers whose value is not set no longer result in nil entries on the event
  - Fix: when adding the `jms_reply_to` header to an event, a string representation is set instead of an opaque object.
+
 ## 3.1.2
  - Docs: Added additional troubleshooting information [#38](https://github.com/logstash-plugins/logstash-input-jms/pull/38)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.2.0
  - Feat: event_factory support + targets to aid ECS [#49](https://github.com/logstash-plugins/logstash-input-jms/pull/49)
-
+ - Fix: when configured to add JMS headers to the event, headers whose value is not set no longer result in nil entries on the event
+ - Fix: when adding the `jms_reply_to` header to an event, a string representation is set instead of an opaque object.
 ## 3.1.2
  - Docs: Added additional troubleshooting information [#38](https://github.com/logstash-plugins/logstash-input-jms/pull/38)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.0
+ - Feat: event_factory support + targets to aid ECS [#49](https://github.com/logstash-plugins/logstash-input-jms/pull/49)
+
 ## 3.1.2
  - Docs: Added additional troubleshooting information [#38](https://github.com/logstash-plugins/logstash-input-jms/pull/38)
 
@@ -45,7 +48,7 @@
  - New dependency requirements for logstash-core for the 5.0 release
 
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -564,7 +564,22 @@ A JMS message has three parts:
 
 You can tell the input plugin which parts should be included in the event produced by Logstash.
 
-Include JMS Message Header Field values in the event.
+Include standard JMS message header field values in the event.
+Example headers:
+[source,ruby]
+-----
+    {
+        "jms_message_id" => "ID:amqhost-39547-1636977297920-71:1:1:1:1",
+        "jms_timestamp" => 1636977329102,
+        "jms_expiration" => 0,
+        "jms_delivery_mode" => "persistent",
+        "jms_redelivered" => false,
+        "jms_destination" => "topic://41ad5342149901ad",
+        "jms_priority" => 4,
+        "jms_type" => "sample",
+        "jms_correlation_id" => "28d975cb-14ff-4285-841e-05ef1e0a7ab2"
+    }
+-----
 
 [id="plugins-{type}s-{plugin}-include_properties"]
 ===== `include_properties`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -35,7 +35,7 @@ JMS configurations can be done either entirely in the Logstash configuration fil
 
 ==== Compatibility with the Elastic Common Schema (ECS)
 
-JMS data is application specific, thus making fields compliant with the Elastic Common Schema depends on the use-case.
+JMS data is application specific. ECS compliance for fields depends on the use case.
 The plugin includes sensible defaults that change based on <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>>.
 See <<plugins-{type}s-{plugin}-headers_target>>, <<plugins-{type}s-{plugin}-properties_target>> and <<plugins-{type}s-{plugin}-target>>.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -37,6 +37,8 @@ JMS configurations can be done either entirely in the Logstash configuration fil
 
 JMS data is application specific. ECS compliance for fields depends on the use case.
 The plugin includes sensible defaults that change based on <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>>.
+When ECS compatibility is disabled, headers, properties, and payload are targeted at the root level of the event to maintain compatibility with legacy usage of this plugin.
+When targeting an ECS version, headers and properties target `@metadata` sub-fields unless configured otherwise in order to avoid conflict with ECS fields.
 See <<plugins-{type}s-{plugin}-headers_target>>, <<plugins-{type}s-{plugin}-properties_target>> and <<plugins-{type}s-{plugin}-target>>.
 
 ==== Sample Configuration using Logstash Configuration Only

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -33,6 +33,7 @@ JMS configurations can be done either entirely in the Logstash configuration fil
   configurations, should also use the combination of yaml file and Logstash configuration.
 
 
+[id="plugins-{type}s-{plugin}-ecs"]
 ==== Compatibility with the Elastic Common Schema (ECS)
 
 JMS data is application specific. ECS compliance for fields depends on the use case.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -33,6 +33,11 @@ JMS configurations can be done either entirely in the Logstash configuration fil
   configurations, should also use the combination of yaml file and Logstash configuration.
 
 
+==== Compatibility with the Elastic Common Schema (ECS)
+
+JMS data is application specific, thus making fields compliant with the Elastic Common Schema depends on the use-case.
+The plugin includes sensible defaults that change based on <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>>.
+See <<plugins-{type}s-{plugin}-headers_target>>, <<plugins-{type}s-{plugin}-properties_target>> and <<plugins-{type}s-{plugin}-target>>.
 
 ==== Sample Configuration using Logstash Configuration Only
 
@@ -60,7 +65,7 @@ The JMS plugin can also be configured using JNDI if desired.
         truststore => '/Users/logstash-user/security/truststore.jks'
         truststore_password => 'yet_another_secret'
         # Parts of the JMS message to be included <8>
-        include_header => false
+        include_headers => false
         include_properties => false
         include_body => true
         # Message selector
@@ -98,7 +103,7 @@ The JMS plugin can also be configured using JNDI if desired.
  input {
     jms {
         # Logstash Configuration Settings. <1>
-        include_header => false
+        include_headers => false
         include_properties => false
         include_body => true
         use_jms_timestamp => false
@@ -144,7 +149,7 @@ This section contains sample configurations for connecting to a JMS provider tha
  input {
     jms {
         # Logstash Configuration File Settings <1>
-        include_header => false
+        include_headers => false
         include_properties => false
         include_body => true
         use_jms_timestamp => false
@@ -205,7 +210,7 @@ This section contains sample configurations for connecting to a JMS provider tha
  input {
     jms {
         # Logstash specific configuration settings <1>
-        include_header => false
+        include_headers => false
         include_properties => false
         include_body => true
         use_jms_timestamp => false
@@ -379,10 +384,13 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-durable_subscriber>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-durable_subscriber_client_id>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-durable_subscriber_name>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-factory>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-factory_settings>> |<<hash,hash>>|No
+| <<plugins-{type}s-{plugin}-headers_target>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-include_body>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-include_header>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-include_headers>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-include_properties>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-interval>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-jndi_context>> |<<hash,hash>>|No
@@ -391,6 +399,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-keystore_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-oracle_aq_buffered_messages>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-password>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-properties_target>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-pub_sub>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-require_jars>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-runner>> |<<string,string>>|__Deprecated__
@@ -398,6 +407,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-skip_headers>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-skip_properties>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-system_properties>> |<<hash,hash>>|No
+| <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-threads>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-truststore>> |a valid filesystem path|No
@@ -468,6 +478,21 @@ This represents the value of the client ID for a durable subscribtion, and is on
 This represents the value of the subscriber name for a durable subscribtion, and is only used if `durable_subscriber`
 is set to `true`. Please consult your JMS Provider documentation for constraints and requirements for this setting.
 
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+  * Value type is <<string,string>>
+  * Supported values are:
+    ** `disabled`: does not use ECS-compatible field names (fields might be set at the root of the event)
+    ** `v1`, `v8`: avoids field names that might conflict with Elastic Common Schema (for example, JMS specific properties)
+  * Default value depends on which version of Logstash is running:
+    ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+    ** Otherwise, the default value is `disabled`.
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
+The value of this setting affects the _default_ value of <<plugins-{type}s-{plugin}-headers_target>> and
+<<plugins-{type}s-{plugin}-properties_target>>.
+
 [id="plugins-{type}s-{plugin}-factory"]
 ===== `factory`
 
@@ -488,6 +513,16 @@ Hash of implementation specific configuration values to set on the connection fa
  `exclusive_consumer => true` would call `setExclusiveConsumer(true)` on the supplied connection factory.
  See your JMS provider documentation for implementation specific details.
 
+[id="plugins-{type}s-{plugin}-headers_target"]
+===== `headers_target`
+
+  * Value type is <<string,string>>
+  * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
+    ** ECS Compatibility disabled: no default value for this setting
+    ** ECS Compatibility enabled: `"[@metadata][input][jms][headers]"
+
+The name of the field under which JMS headers will be added, if <<plugins-{type}s-{plugin}-include_headers>> is set.
+
 [id="plugins-{type}s-{plugin}-include_body"]
 ===== `include_body`
 
@@ -495,11 +530,12 @@ Hash of implementation specific configuration values to set on the connection fa
   * Default value is `true`
 
 Include JMS Message Body in the event.
-Supports TextMessage, MapMessage and ByteMessage.
+Supports TextMessage, MapMessage and BytesMessage.
 
-If the JMS Message is a TextMessage or ByteMessage, then the value will be in
+If the JMS Message is a TextMessage or BytesMessage, then the value will be in
 the "message" field of the event. If the JMS Message is a MapMessage, then all
-the key/value pairs will be added in the Hashmap of the event.
+the key/value pairs will be added at the top-level of the event by default.
+To avoid pollution of the top-level namespace, when receiving a MapMessage, use the <<plugins-{type}s-{plugin}-target>>.
 
 StreamMessage and ObjectMessage are not supported.
 
@@ -507,13 +543,22 @@ StreamMessage and ObjectMessage are not supported.
 ===== `include_header`
 
   * Value type is <<boolean,boolean>>
+  * This option is deprecated
+
+Note: This option is deprecated and it will be removed in the next major version of Logstash.
+Use `include_headers` instead.
+
+[id="plugins-{type}s-{plugin}-include_headers"]
+===== `include_headers`
+
+  * Value type is <<boolean,boolean>>
   * Default value is `true`
 
 A JMS message has three parts:
 
-* Message Headers (required)
-* Message Properties (optional)
-* Message Bodies (optional)
+  * Message Headers (required)
+  * Message Properties (optional)
+  * Message Body (optional)
 
 You can tell the input plugin which parts should be included in the event produced by Logstash.
 
@@ -590,6 +635,16 @@ Only for use with Oracle AQ
 
 Password to use when connecting to the JMS provider.
 
+[id="plugins-{type}s-{plugin}-properties_target"]
+===== `properties_target`
+
+  * Value type is <<string,string>>
+  * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
+    ** ECS Compatibility disabled: no default value for this setting
+    ** ECS Compatibility enabled: `"[@metadata][input][jms][properties]"
+
+The name of the field under which JMS properties will be added, if <<plugins-{type}s-{plugin}-include_properties>> is set.
+
 [id="plugins-{type}s-{plugin}-pub_sub"]
 ===== `pub_sub`
 
@@ -650,6 +705,17 @@ If `include_properties` is set, a list of properties to skip processing on can b
 
 Any System properties that the JMS provider requires can be set either in a Hash here, or in `jvm.options`
 
+[id="plugins-{type}s-{plugin}-target"]
+===== `target`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+The name of the field to assign MapMessage data into.
+If not specified data will be stored in the root of the event.
+
+NOTE: For TextMessage and BytesMessage the `target` has no effect. Use the codec setting instead
+e.g. `codec => json { target => "[jms]" }`.
 
 [id="plugins-{type}s-{plugin}-threads"]
 ===== `threads`
@@ -657,7 +723,7 @@ Any System properties that the JMS provider requires can be set either in a Hash
   * Value type is <<number,number>>
   * Default value is `1`
 
-* Note that if pub_sub is set to true, this value *must* be 1. A configuration error will be thrown otherwise
+NOTE: If pub_sub is set to `true`, this value *must* be `1`. A configuration error will be thrown otherwise!
 
 [id="plugins-{type}s-{plugin}-timeout"]
 ===== `timeout`

--- a/lib/logstash/inputs/jms.rb
+++ b/lib/logstash/inputs/jms.rb
@@ -137,7 +137,7 @@ class LogStash::Inputs::Jms < LogStash::Inputs::Threadable
   # If this setting is omitted, data gets stored at the root (top level) of the event.
   # The target is only relevant while decoding data into a new event.
   #
-  # NOTE: this is only relevant for map messages, byte[] and string use the codec!
+  # NOTE: this is only relevant for map messages; byte[] and string use the codec!
   config :target, :validate => :field_reference
 
   config :headers_target, :validate => :field_reference # ECS default: [@metadata][input][jms][headers]

--- a/lib/logstash/inputs/jms.rb
+++ b/lib/logstash/inputs/jms.rb
@@ -404,11 +404,16 @@ class LogStash::Inputs::Jms < LogStash::Inputs::Threadable
 
   private
 
+  def normalize_field_ref(target)
+    # so we can later event.set("#{target}[#{name}]", ...)
+    target.match?(/\A[^\[\]]+\z/) ? "[#{target}]" : target
+  end
+
   def event_setter_for(target)
     if target.nil? || target.empty?
       TOP_LEVEL_EVENT_SETTER
     else
-      TargetEventSetter.new(target)
+      TargetEventSetter.new normalize_field_ref(target)
     end
   end
 
@@ -422,7 +427,7 @@ class LogStash::Inputs::Jms < LogStash::Inputs::Threadable
     end
 
     def call(event, data)
-      event.set(@target, data)
+      data.each { |key, val| event.set("#{@target}[#{key}]", val) }
     end
 
   end

--- a/lib/logstash/inputs/jms.rb
+++ b/lib/logstash/inputs/jms.rb
@@ -463,13 +463,15 @@ class LogStash::Inputs::Jms < LogStash::Inputs::Threadable
     def call(msg)
       map = {
         'jms_message_id' => msg.getJMSMessageID, # String
-        'jms_correlation_id' => msg.getJMSCorrelationID, # String
         'jms_timestamp' => msg.getJMSTimestamp, # long
         'jms_expiration' => msg.getJMSExpiration, # long
         'jms_priority' => msg.getJMSPriority, # int (0-9)
         'jms_type' => msg.getJMSType, # String
         'jms_redelivered' => msg.getJMSRedelivered, # boolean
       }
+
+      correlation_id = msg.getJMSCorrelationID # String
+      map['jms_correlation_id'] = correlation_id unless correlation_id.nil?
 
       delivery_mode = jms_delivery_mode(msg)
       map['jms_delivery_mode'] = delivery_mode unless delivery_mode.nil?

--- a/lib/logstash/inputs/jms.rb
+++ b/lib/logstash/inputs/jms.rb
@@ -465,7 +465,6 @@ class LogStash::Inputs::Jms < LogStash::Inputs::Threadable
         'jms_message_id' => msg.getJMSMessageID, # String
         'jms_correlation_id' => msg.getJMSCorrelationID, # String
         'jms_timestamp' => msg.getJMSTimestamp, # long
-        'jms_delivery_time' => msg.getJMSDeliveryTime, # long
         'jms_expiration' => msg.getJMSExpiration, # long
         'jms_priority' => msg.getJMSPriority, # int (0-9)
         'jms_type' => msg.getJMSType, # String

--- a/lib/logstash/inputs/jms.rb
+++ b/lib/logstash/inputs/jms.rb
@@ -507,7 +507,8 @@ class LogStash::Inputs::Jms < LogStash::Inputs::Threadable
 
     def call(msg)
       map = super(msg)
-      map['jms_delivery_mode_sym'] = jms_delivery_mode(msg)
+      delivery_mode = jms_delivery_mode(msg)
+      map['jms_delivery_mode_sym'] = delivery_mode ? delivery_mode.to_sym : nil
       map
     end
 

--- a/lib/logstash/inputs/jms.rb
+++ b/lib/logstash/inputs/jms.rb
@@ -156,12 +156,9 @@ class LogStash::Inputs::Jms < LogStash::Inputs::Threadable
   def initialize(*params)
     super
 
-    unless original_params.include?('headers_target')
-      @headers_target = ecs_select[disabled: nil, v1: '[@metadata][input][jms][headers]']
-    end
-
-    unless original_params.include?('properties_target')
-      @properties_target = ecs_select[disabled: nil, v1: '[@metadata][input][jms][properties]']
+    if ecs_compatibility != :disabled # set ECS target defaults
+      @headers_target = '[@metadata][input][jms][headers]' unless original_params.include?('headers_target')
+      @properties_target = '[@metadata][input][jms][properties]' unless original_params.include?('properties_target')
     end
 
     @headers_setter = event_setter_for(@headers_target)

--- a/lib/logstash/inputs/jms.rb
+++ b/lib/logstash/inputs/jms.rb
@@ -42,7 +42,7 @@ class LogStash::Inputs::Jms < LogStash::Inputs::Threadable
   # You can tell the input plugin which parts should be included in the event produced by Logstash
   #
   # Include JMS Message Header Field values in the event
-  config :include_header, :validate => :boolean, :default => false, :deprecated => "Set 'include_headers => ...' instead"
+  config :include_header, :validate => :boolean, :deprecated => "Set 'include_headers => ...' instead"
   config :include_headers, :validate => :boolean, :default => true
   # Include JMS Message Properties Field values in the event
   config :include_properties, :validate => :boolean, :default => true

--- a/lib/logstash/inputs/jms.rb
+++ b/lib/logstash/inputs/jms.rb
@@ -48,12 +48,12 @@ class LogStash::Inputs::Jms < LogStash::Inputs::Threadable
   # If the JMS Message is a MapMessage, then all the key/value pairs will be added in the Hashmap of the event
   # StreamMessage and ObjectMessage are not supported
 
-  # Receive Oracle AQ buffered messages. 
+  # Receive Oracle AQ buffered messages.
   # In this mode persistent Oracle AQ JMS messages will not be received.
   config :oracle_aq_buffered_messages, :validate => :boolean, :default => false
 
   config :include_body, :validate => :boolean, :default => true
-  
+
   # Convert the JMSTimestamp header field to the @timestamp value of the event
   config :use_jms_timestamp, :validate => :boolean, :default => false
 
@@ -262,8 +262,9 @@ class LogStash::Inputs::Jms < LogStash::Inputs::Threadable
             event.set(field.to_s, value) # TODO(claveau): needs codec.decode or converter.convert ?
           end
         elsif msg.java_kind_of?(JMS::TextMessage) || msg.java_kind_of?(JMS::BytesMessage)
-          unless msg.to_s.nil?
-            @codec.decode(msg.to_s) do |event_message|
+          text = msg.to_s
+          unless text.nil?
+            @codec.decode(text) do |event_message|
               event = event_message
             end
           end

--- a/logstash-input-jms.gemspec
+++ b/logstash-input-jms.gemspec
@@ -19,16 +19,16 @@ Gem::Specification.new do |s|
   # Special flag to let us know this is actually a logstash plugin
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "input" }
 
+  s.platform = RUBY_PLATFORM
+
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-json', '~> 3.0'
   s.add_runtime_dependency 'logstash-codec-plain', '~> 3.0'
   s.add_runtime_dependency "logstash-mixin-event_support", '~> 1.0'
+
+  s.add_runtime_dependency "jruby-jms", ">= 1.2.0" #(Apache 2.0 license)
   s.add_runtime_dependency 'semantic_logger', '< 4.0.0'
 
-  if RUBY_PLATFORM == 'java'
-    s.platform = RUBY_PLATFORM
-    s.add_runtime_dependency "jruby-jms", ">= 1.2.0" #(Apache 2.0 license)
-  end
   s.add_development_dependency 'logstash-devutils'
 end

--- a/logstash-input-jms.gemspec
+++ b/logstash-input-jms.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-jms'
-  s.version         = '3.1.2'
+  s.version         = '3.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from a Jms Broker"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-jms.gemspec
+++ b/logstash-input-jms.gemspec
@@ -25,7 +25,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-json', '~> 3.0'
   s.add_runtime_dependency 'logstash-codec-plain', '~> 3.0'
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.3'
   s.add_runtime_dependency "logstash-mixin-event_support", '~> 1.0'
+  s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
 
   s.add_runtime_dependency "jruby-jms", ">= 1.2.0" #(Apache 2.0 license)
   s.add_runtime_dependency 'semantic_logger', '< 4.0.0'

--- a/logstash-input-jms.gemspec
+++ b/logstash-input-jms.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-json', '~> 3.0'
   s.add_runtime_dependency 'logstash-codec-plain', '~> 3.0'
+  s.add_runtime_dependency "logstash-mixin-event_support", '~> 1.0'
   s.add_runtime_dependency 'semantic_logger', '< 4.0.0'
 
   if RUBY_PLATFORM == 'java'

--- a/setup_broker.sh
+++ b/setup_broker.sh
@@ -4,7 +4,7 @@ set -xe
 if [ -n "${ACTIVEMQ_VERSION+1}" ]; then
   echo "ACTIVEMQ_VERSION is $ACTIVEMQ_VERSION"
 else
-   ACTIVEMQ_VERSION=5.15.8
+   ACTIVEMQ_VERSION=5.15.14
 fi
 
 curl -s -o activemq-all.jar https://repo1.maven.org/maven2/org/apache/activemq/activemq-all/$ACTIVEMQ_VERSION/activemq-all-$ACTIVEMQ_VERSION.jar

--- a/spec/inputs/integration/jms_spec.rb
+++ b/spec/inputs/integration/jms_spec.rb
@@ -218,10 +218,15 @@ shared_examples_for "a JMS input" do
               expect(event.include?('jms_destination')).to be false
               expect(event.get('[@metadata][input][jms][headers][jms_timestamp]')).to be_a Integer
               expect(event.get('[@metadata][input][jms][headers][jms_destination]')).to_not be nil
+              expect(event.include?("[@metadata][input][jms][headers][jms_delivery_mode_sym]")).to be false
+              expect(event.include?("[@metadata][input][jms][headers][jms_delivery_mode]")).to be true
             else
               expect(event.get('jms_timestamp')).to be_a Integer
               expect(event.get('jms_destination')).to_not be nil
+              expect(event.include?("jms_delivery_mode_sym")).to be true
             end
+
+            pp event.to_hash_with_metadata
 
             # properties
             if ecs_compatibility?
@@ -265,8 +270,11 @@ shared_examples_for "a JMS input" do
 
           if ecs_compatibility?
             expect(event.get('[@metadata][input][jms][headers][jms_destination]')).to eql(destination)
+            expect(event.get('[@metadata][input][jms][headers][jms_delivery_mode]')).to eql 'persistent'
+            expect(event.include?('[@metadata][input][jms][headers][jms_delivery_mode_sym]')).to be false
           else
             expect(event.get("jms_destination")).to eql(destination)
+            expect(event.get("jms_delivery_mode_sym")).to eql 'persistent'
           end
 
           send_message # should not log the ECS warning again

--- a/spec/inputs/integration/jms_spec.rb
+++ b/spec/inputs/integration/jms_spec.rb
@@ -226,8 +226,6 @@ shared_examples_for "a JMS input" do
               expect(event.include?("jms_delivery_mode_sym")).to be true
             end
 
-            pp event.to_hash_with_metadata
-
             # properties
             if ecs_compatibility?
               expect(event.include?('this')).to be false

--- a/spec/inputs/integration/jms_spec.rb
+++ b/spec/inputs/integration/jms_spec.rb
@@ -1,5 +1,6 @@
 require_relative '../spec_helper'
 require 'logstash/inputs/jms'
+require 'logstash/plugin_mixins/ecs_compatibility_support/spec_helper'
 require 'securerandom'
 
 shared_examples_for "a JMS input" do
@@ -11,7 +12,7 @@ shared_examples_for "a JMS input" do
       let(:message) { "Hello There" }
 
       context 'when properties are skipped' do
-        let (:jms_config) { super().merge({'skip_properties' => ['this', 'that']})}
+        let (:config) { super().merge({'skip_properties' => ['this', 'that']})}
 
         it 'should skip the specified property and process other properties, headers and the message' do
           send_message do |session|
@@ -21,7 +22,7 @@ shared_examples_for "a JMS input" do
             msg.set_string_property('the_other', 'the_other_prop')
             msg
           end
-          expect(queue.first.get('message')).to eql (message)
+          expect(queue.first.get('message')).to eql(message)
           expect(queue.first.get('jms_destination')).to_not be_nil
           expect(queue.first.get('jms_timestamp')).to_not be_nil
           expect(queue.first.get('this')).to be_nil
@@ -31,7 +32,7 @@ shared_examples_for "a JMS input" do
       end
 
       context 'when using message selectors' do
-        let (:jms_config) { super().merge({'selector' => selector }) }
+        let (:config) { super().merge({'selector' => selector }) }
 
         context 'with multiple selector query parameter' do
           let (:selector) { "this = 3 OR this = 4" }
@@ -43,7 +44,7 @@ shared_examples_for "a JMS input" do
               msg.set_int_property('this', 4)
               msg
             end
-            expect(queue.first.get('message')).to eql (message)
+            expect(queue.first.get('message')).to eql(message)
             expect(queue.first.get('this')).to eql(4)
             expect(queue.first.get('that')).to eql('that_prop')
           end
@@ -69,7 +70,7 @@ shared_examples_for "a JMS input" do
               msg.set_int_property('this', 3)
               msg
             end
-            expect(queue.first.get('message')).to eql (message)
+            expect(queue.first.get('message')).to eql(message)
             expect(queue.first.get('this')).to eql(3)
             expect(queue.first.get('that')).to eql('that_prop')
           end
@@ -122,7 +123,7 @@ shared_examples_for "a JMS input" do
               msg.set_string_property('that', 'that_prop')
               msg
             end
-            expect(queue.first.get('message')).to eql (message)
+            expect(queue.first.get('message')).to eql(message)
             expect(queue.first.get('this')).to eql('this_prop')
             expect(queue.first.get('that')).to eql('that_prop')
           end
@@ -141,7 +142,7 @@ shared_examples_for "a JMS input" do
       end
 
       context 'when headers are skipped' do
-        let (:jms_config) { super().merge('skip_headers' => ['jms_destination', 'jms_reply_to']) }
+        let (:config) { super().merge('skip_headers' => ['jms_destination', 'jms_reply_to']) }
 
         it 'should skip the specified header and process other headers, properties and the message' do
           send_message do |session|
@@ -152,7 +153,7 @@ shared_examples_for "a JMS input" do
             msg.set_string_property('the_other', 'the_other_prop')
             msg
           end
-          expect(queue.first.get('message')).to eql (message)
+          expect(queue.first.get('message')).to eql(message)
           expect(queue.first.get('jms_destination')).to be_nil
           expect(queue.first.get('jms_timestamp')).to_not be_nil
           expect(queue.first.get('this')).to eq('this_prop')
@@ -162,7 +163,7 @@ shared_examples_for "a JMS input" do
       end
 
       context 'when include_headers => false' do
-        let (:jms_config) { super().merge('include_headers' => 'false') }
+        let (:config) { super().merge('include_headers' => 'false') }
 
         it 'should skip all headers' do
           send_message do |session|
@@ -177,7 +178,7 @@ shared_examples_for "a JMS input" do
       end
 
       context 'when include_header => false (deprecated)' do
-        let (:jms_config) { super().merge('include_header' => 'false') }
+        let (:config) { super().merge('include_header' => 'false') }
 
         it 'should skip all headers' do
           send_message do |session|
@@ -191,21 +192,50 @@ shared_examples_for "a JMS input" do
         end
       end
 
-      context 'when neither header nor property is skipped ' do
-        it 'should process properties, headers and the message' do
-          send_message do |session|
-            msg = session.message(message)
-            msg.set_string_property('this', 'this_prop')
-            msg.set_int_property('camelCase', 42)
-            msg.set_boolean_property('JMSFlag', true)
-            msg
+      context 'when neither header nor property is skipped', :ecs_compatibility_support do
+        ecs_compatibility_matrix(:disabled, :v1, :v8) do |ecs_select|
+
+          let(:ecs_compatibility?) { ecs_select.active_mode != :disabled }
+
+          let (:config) { super().merge('ecs_compatibility' => ecs_select.active_mode) }
+
+          it 'should process properties, headers and the message' do
+            send_message do |session|
+              msg = session.message(message)
+              msg.set_string_property('this', 'this_prop')
+              msg.set_int_property('camelCase', 42)
+              msg.set_boolean_property('JMSFlag', true)
+              msg
+            end
+
+            event = queue.first
+
+            expect(event.get('message')).to eql(message)
+
+            # headers
+            if ecs_compatibility?
+              expect(event.include?('jms_timestamp')).to be false
+              expect(event.include?('jms_destination')).to be false
+              expect(event.get('[@metadata][input][jms][headers][jms_timestamp]')).to be_a Integer
+              expect(event.get('[@metadata][input][jms][headers][jms_destination]')).to_not be nil
+            else
+              expect(event.get('jms_timestamp')).to be_a Integer
+              expect(event.get('jms_destination')).to_not be nil
+            end
+
+            # properties
+            if ecs_compatibility?
+              expect(event.include?('this')).to be false
+              expect(event.get('[@metadata][input][jms][properties][this]')).to eq 'this_prop'
+              expect(event.get('[@metadata][input][jms][properties][camelCase]')).to eq 42
+              expect(event.get('[@metadata][input][jms][properties][JMSFlag]')).to be true
+            else
+              expect(event.get('this')).to eq 'this_prop'
+              expect(event.get('camelCase')).to eq 42
+              expect(event.get('JMSFlag')).to be true
+            end
           end
-          expect(queue.first.get('message')).to eql (message)
-          expect(queue.first.get('jms_timestamp')).to_not be_nil
-          expect(queue.first.get('jms_destination')).to_not be_nil
-          expect(queue.first.get('this')).to eq('this_prop')
-          expect(queue.first.get('camelCase')).to eq(42)
-          expect(queue.first.get('JMSFlag')).to be true
+
         end
       end
     end
@@ -215,7 +245,7 @@ shared_examples_for "a JMS input" do
       it 'should read the message' do
         send_message
         expect(queue.size).to eql 1
-        expect(queue.first.get('one')).to eql (1)
+        expect(queue.first.get('one')).to eql 1
         expect(queue.first.get("jms_destination")).to eql(destination)
       end
     end
@@ -230,16 +260,25 @@ shared_examples_for "a JMS input" do
           jms_message
         end
         expect(queue.size).to eql 1
-        expect(queue.first.get('message')).to eql ('hello world')
+        expect(queue.first.get('message')).to eql 'hello world'
         expect(queue.first.get("jms_destination")).to eql(destination)
       end
     end
   end
 end
 
-describe "input/jms", :integration => true do
+describe LogStash::Inputs::Jms, :integration => true do
   let (:message) { "hello World" }
   let (:queue_name) { SecureRandom.hex(8)}
+
+  let (:yaml_section) { 'activemq' }
+  let (:config) {{'yaml_file' => fixture_path("jms.yml"),
+                      'yaml_section' => yaml_section,
+                      'destination' => queue_name,
+                      'pub_sub' => pub_sub,
+                      'interval' => 2}}
+
+  let(:input) { described_class.new(config) }
 
   before :each do
     allow(input).to receive(:jms_config_from_yaml) do |yaml_file, section|
@@ -248,14 +287,6 @@ describe "input/jms", :integration => true do
       settings
     end
   end
-
-  let (:yaml_section) { 'activemq' }
-  let (:jms_config) {{'yaml_file' => fixture_path("jms.yml"),
-                      'yaml_section' => yaml_section,
-                      'destination' => queue_name,
-                      'pub_sub' => pub_sub,
-                      'interval' => 2}}
-  let(:input) { LogStash::Plugin.lookup("input", "jms").new(jms_config) }
 
   after :each do
     input.close unless input.nil?
@@ -268,7 +299,7 @@ describe "input/jms", :integration => true do
     end
 
     context 'with pub_sub true and durable subscriber' do
-      let (:jms_config) { super().merge({'durable_subscriber' => true,
+      let (:config) { super().merge({'durable_subscriber' => true,
                            'durable_subscriber_client_id' => SecureRandom.hex(8),
                            'durable_subscriber_name' => SecureRandom.hex(8) } ) }
 
@@ -285,8 +316,8 @@ describe "input/jms", :integration => true do
 
   context 'with tls', :tls => true do
     let (:yaml_section) { 'activemq_tls' }
-    let (:jms_config) { super().merge({"keystore" => fixture_path("keystore.jks"), "keystore_password" => "changeit",
-                                     "truststore" => fixture_path("keystore.jks"), "truststore_password" => "changeit"})}
+    let (:config) { super().merge({"keystore" => fixture_path("keystore.jks"), "keystore_password" => "changeit",
+                                   "truststore" => fixture_path("keystore.jks"), "truststore_password" => "changeit"})}
 
     context 'with pub_sub true' do
       let (:pub_sub) { true }
@@ -294,7 +325,7 @@ describe "input/jms", :integration => true do
     end
 
     context 'with pub_sub true and durable subscriber' do
-      let (:jms_config) { super().merge({'durable_subscriber' => true,
+      let (:config) { super().merge({'durable_subscriber' => true,
                            'durable_subscriber_client_id' => SecureRandom.hex(8),
                            'durable_subscriber_name' => SecureRandom.hex(8) } ) }
 

--- a/spec/inputs/integration/jms_spec.rb
+++ b/spec/inputs/integration/jms_spec.rb
@@ -272,7 +272,7 @@ shared_examples_for "a JMS input" do
             expect(event.include?('[@metadata][input][jms][headers][jms_delivery_mode_sym]')).to be false
           else
             expect(event.get("jms_destination")).to eql(destination)
-            expect(event.get("jms_delivery_mode_sym")).to eql 'persistent'
+            expect(event.get("jms_delivery_mode_sym")).to eql :persistent
           end
 
           send_message # should not log the ECS warning again

--- a/spec/inputs/integration/jms_spec.rb
+++ b/spec/inputs/integration/jms_spec.rb
@@ -1,7 +1,5 @@
 require_relative '../spec_helper'
 require 'logstash/inputs/jms'
-require 'jms'
-require 'json'
 require 'securerandom'
 
 shared_examples_for "a JMS input" do

--- a/spec/inputs/integration/jms_spec.rb
+++ b/spec/inputs/integration/jms_spec.rb
@@ -278,7 +278,7 @@ describe LogStash::Inputs::Jms, :integration => true do
                       'pub_sub' => pub_sub,
                       'interval' => 2}}
 
-  let(:input) { described_class.new(config) }
+  subject(:input) { described_class.new(config) }
 
   before :each do
     allow(input).to receive(:jms_config_from_yaml) do |yaml_file, section|

--- a/spec/inputs/integration/jms_spec.rb
+++ b/spec/inputs/integration/jms_spec.rb
@@ -4,8 +4,6 @@ require 'jms'
 require 'json'
 require 'securerandom'
 
-
-
 shared_examples_for "a JMS input" do
   context 'when inputting messages' do
     let (:destination) { "#{pub_sub ? 'topic' : 'queue'}://#{queue_name}"}

--- a/spec/inputs/unit/jms_spec.rb
+++ b/spec/inputs/unit/jms_spec.rb
@@ -252,4 +252,13 @@ describe "inputs/jms" do
       end
     end
   end
+
+  context 'invalid configuration' do
+    let (:jms_config) { super().merge('include_headers' => true, 'include_header' => false) }
+
+    it 'should raise a configuration error' do
+      expect { subject.register }.to raise_error LogStash::ConfigurationError,
+                                                 /Both `include_headers => true` and `include_header => false` options are specified/i
+    end
+  end
 end

--- a/spec/inputs/unit/jms_spec.rb
+++ b/spec/inputs/unit/jms_spec.rb
@@ -1,7 +1,6 @@
 require_relative '../spec_helper'
 require 'logstash/inputs/jms'
-require 'jms'
-require 'json'
+require 'securerandom'
 
 describe "inputs/jms" do
   let (:queue_name) {SecureRandom.hex(8)}

--- a/spec/inputs/unit/jms_spec.rb
+++ b/spec/inputs/unit/jms_spec.rb
@@ -280,8 +280,8 @@ describe LogStash::Inputs::Jms do
       let(:jms_message_double) do
         message = double('jms-message-stub')
         allow(message).to receive(:jms_timestamp).and_return(jms_timestamp)
-        allow(message).to receive(:attributes).and_return(
-            jms_message_id: 'id1', jms_timestamp: jms_timestamp, jms_destination: nil, jms_expiration: nil
+        allow_any_instance_of(described_class).to receive(:map_headers).and_return(
+            'jms_message_id' => 'id1', 'jms_timestamp' => jms_timestamp, 'jms_expiration' => nil
         )
         allow(message).to receive(:properties).and_return(:foo => 'bar', 'the-baz' => 42)
         message
@@ -292,6 +292,7 @@ describe LogStash::Inputs::Jms do
 
         plugin.register
         plugin.queue_event(jms_message_double, queue = [])
+        expect(queue.size).to eql 1
         @event = queue.first
       end
 


### PR DESCRIPTION
The PR represents improvements to aid ECS compliant ingestion scenarios.

For context on what this PR is trying to achieve see https://github.com/logstash-plugins/logstash-input-jms/issues/45

### Changes

- added `target` option - used with MapMessage to de-root fields obtained from the JMS map
  note: other message types (TextMessage and BytesMessage) are using the codec
- added `headers_target` to have a name-space for JMS headers (since `include_headers` is enabled by default),
  in ECS mode the `[@metadata][input][jms][headers]` default is used
  note: headers (due jruby-jms) are always `dash_erized` :white_check_mark: ECS
- added `properties_target` to have a name-space for JMS properties (since `include_properties` is enabled by default),
  in ECS mode the `[@metadata][input][jms][properties]` default is used
  note: properties are always vendor/user specific - no (ECS) name normalization occurs

- renamed `include_header` to `include_headers` (`include_header` gets deprecated)