### PR TITLE
Fix: improve compatibility with MessageConsumer implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.1
+ - Fix: improve compatibility with MessageConsumer implementations [#51](https://github.com/logstash-plugins/logstash-input-jms/pull/51)
+
 ## 3.2.0
  - Feat: event_factory support + targets to aid ECS [#49](https://github.com/logstash-plugins/logstash-input-jms/pull/49)
  - Fix: when configured to add JMS headers to the event, headers whose value is not set no longer result in nil entries on the event

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.2.1
- - Fix: improve compatibility with MessageConsumer implementations [#51](https://github.com/logstash-plugins/logstash-input-jms/pull/51)
+ - Fix: improve compatibility with MessageConsumer implementations [#51](https://github.com/logstash-plugins/logstash-input-jms/pull/51),
+   such as IBM MQ.
 
 ## 3.2.0
  - Feat: event_factory support + targets to aid ECS [#49](https://github.com/logstash-plugins/logstash-input-jms/pull/49)

--- a/logstash-input-jms.gemspec
+++ b/logstash-input-jms.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-jms'
-  s.version         = '3.2.0'
+  s.version         = '3.2.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from a Jms Broker"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/spec_helper.rb
+++ b/spec/inputs/spec_helper.rb
@@ -32,6 +32,5 @@ def send_message(&block)
   end
   input.run(queue)
 
-  destination = "#{pub_sub ? 'topic' : 'queue'}://#{queue_name}"
   tt.join(3)
 end


### PR DESCRIPTION
### avoid `MessageConsumer` get/each methods

The gist of this fix is to rely less on JMS's gems extension methods.

JMS extends `javax.jms.MessageConsumer` interface with [`each`](https://github.com/reidmorrison/jruby-jms/blob/master/lib/jms/message_consumer.rb#L57) and [`get`](https://github.com/reidmorrison/jruby-jms/blob/master/lib/jms/message_consumer.rb#L14) methods.

These might end up clashing if some other Java part includes the `get` method or implements `java.lang.Iterable` (JRuby extends these with `Enumerable` and provides an `each` method), this is the case with IBM's [MQTopicSubscriber](https://www.ibm.com/docs/en/ibm-mq/8.0?topic=jms-mqtopicsubscriber) implementation which also implements `java.util.Map` (as explained in https://github.com/logstash-plugins/logstash-input-jms/issues/43#issuecomment-957365566)