### PR TITLE
[Test] Fix integration tests for 8.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## unreleased
+ - Fix: Fix test failures due to ECS compatibility default changes in `8.x` of logstash [#53](https://github.com/logstash-plugins/logstash-input-jms/pull/53)
+
 ## 3.2.0
  - Feat: event_factory support + targets to aid ECS [#49](https://github.com/logstash-plugins/logstash-input-jms/pull/49)
  - Fix: when configured to add JMS headers to the event, headers whose value is not set no longer result in nil entries on the event

--- a/spec/inputs/integration/jms_spec.rb
+++ b/spec/inputs/integration/jms_spec.rb
@@ -23,11 +23,11 @@ shared_examples_for "a JMS input" do
             msg
           end
           expect(queue.first.get('message')).to eql(message)
-          expect(queue.first.get('jms_destination')).to_not be_nil
-          expect(queue.first.get('jms_timestamp')).to_not be_nil
-          expect(queue.first.get('this')).to be_nil
-          expect(queue.first.get('that')).to be_nil
-          expect(queue.first.get('the_other')).to eql('the_other_prop')
+          expect(queue.first).to have_header('jms_destination')
+          expect(queue.first).to have_header('jms_timestamp')
+          expect(queue.first).not_to have_property('this')
+          expect(queue.first).not_to have_property('this')
+          expect(queue.first).to have_property_value('the_other', 'the_other_prop')
         end
       end
 
@@ -45,8 +45,8 @@ shared_examples_for "a JMS input" do
               msg
             end
             expect(queue.first.get('message')).to eql(message)
-            expect(queue.first.get('this')).to eql(4)
-            expect(queue.first.get('that')).to eql('that_prop')
+            expect(queue.first).to have_property_value('this', 4)
+            expect(queue.first).to have_property_value('that', 'that_prop')
           end
 
           it 'does not process messages that do not conform to the message selector' do
@@ -71,8 +71,8 @@ shared_examples_for "a JMS input" do
               msg
             end
             expect(queue.first.get('message')).to eql(message)
-            expect(queue.first.get('this')).to eql(3)
-            expect(queue.first.get('that')).to eql('that_prop')
+            expect(queue.first).to have_property_value('this', 3)
+            expect(queue.first).to have_property_value('that', 'that_prop')
           end
 
           it 'does not process messages that do not conform to the message selector' do
@@ -97,8 +97,8 @@ shared_examples_for "a JMS input" do
               msg
             end
             expect(queue.first.get('message')).to eql(message)
-            expect(queue.first.get('this')).to be_within(0.001).of(3.1)
-            expect(queue.first.get('that')).to eql('that_prop')
+            expect(get_property_value(queue.first, 'this')).to be_within(0.001).of(3.1)
+            expect(queue.first).to have_property_value('that', 'that_prop')
           end
 
           it 'does not process messages that do not conform to the message selector' do
@@ -124,8 +124,8 @@ shared_examples_for "a JMS input" do
               msg
             end
             expect(queue.first.get('message')).to eql(message)
-            expect(queue.first.get('this')).to eql('this_prop')
-            expect(queue.first.get('that')).to eql('that_prop')
+            expect(queue.first).to have_property_value('this', 'this_prop')
+            expect(queue.first).to have_property_value('that', 'that_prop')
           end
 
           it 'does not process messages that do not conform to the message selector' do
@@ -154,11 +154,11 @@ shared_examples_for "a JMS input" do
             msg
           end
           expect(queue.first.get('message')).to eql(message)
-          expect(queue.first.get('jms_destination')).to be_nil
-          expect(queue.first.get('jms_timestamp')).to_not be_nil
-          expect(queue.first.get('this')).to eq('this_prop')
-          expect(queue.first.get('that')).to eq('that_prop')
-          expect(queue.first.get('the_other')).to eq('the_other_prop')
+          expect(queue.first).not_to have_header('jms_destination')
+          expect(queue.first).to have_header('jms_timestamp')
+          expect(queue.first).to have_property_value('this', 'this_prop')
+          expect(queue.first).to have_property_value('that', 'that_prop')
+          expect(queue.first).to have_property_value('the_other', 'the_other_prop')
         end
       end
 
@@ -293,7 +293,7 @@ shared_examples_for "a JMS input" do
         end
         expect(queue.size).to eql 1
         expect(queue.first.get('message')).to eql 'hello world'
-        expect(queue.first.get("jms_destination")).to eql(destination)
+        expect(queue.first).to have_header_value("jms_destination", destination)
       end
     end
   end

--- a/spec/inputs/spec_helper.rb
+++ b/spec/inputs/spec_helper.rb
@@ -35,3 +35,40 @@ def send_message(&block)
   destination = "#{pub_sub ? 'topic' : 'queue'}://#{queue_name}"
   tt.join(3)
 end
+
+
+def get_value(type, actual, name)
+  actual.get(name) || actual.get("[@metadata][input][jms][#{type}][#{name}]")
+end
+
+def get_header_value(actual, name)
+  get_value('headers', actual, name)
+end
+
+def get_property_value(actual, name)
+  get_value('properties', actual, name)
+end
+
+RSpec::Matchers.define :have_header do |expected|
+  match do |actual|
+    get_header_value(actual, expected)
+  end
+end
+
+RSpec::Matchers.define :have_property do |expected|
+  match do |actual|
+    get_property_value(actual, expected)
+  end
+end
+
+RSpec::Matchers.define :have_header_value do |header, expected|
+  match do |actual|
+    expected == get_header_value(actual, header)
+  end
+end
+
+RSpec::Matchers.define :have_property_value do |property, expected|
+  match do |actual|
+    expected == get_property_value(actual, property)
+  end
+end


### PR DESCRIPTION
The change to ECS compatibility by default in 8.x has broken a large number of
integration tests expecting header and property values in the "old" location. This
commit fixes the integration tests by adding matchers that will check both locations
for header and property values
