### PR TITLE
Remove usage of `java_kind_of?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.2
+ - Fix: Remove usage of `java_kind_of?` to allow this plugin to be supported for versions of Logstash using jruby-9.3.x
+ [#54](https://github.com/logstash-plugins/logstash-input-jms/pull/54)
+
 ## 3.2.1
  - Fix: improve compatibility with MessageConsumer implementations [#51](https://github.com/logstash-plugins/logstash-input-jms/pull/51),
    such as IBM MQ.

--- a/lib/logstash/inputs/jms.rb
+++ b/lib/logstash/inputs/jms.rb
@@ -299,9 +299,9 @@ class LogStash::Inputs::Jms < LogStash::Inputs::Threadable
   def queue_event(msg, output_queue)
     begin
       if @include_body
-        if msg.java_kind_of?(JMS::MapMessage)
+        if msg.kind_of?(JMS::MapMessage)
           event = process_map_message(msg)
-        elsif msg.java_kind_of?(JMS::TextMessage) || msg.java_kind_of?(JMS::BytesMessage)
+        elsif msg.kind_of?(JMS::TextMessage) || msg.kind_of?(JMS::BytesMessage)
           event = decode_message(msg)
         else
           @logger.error( "Unsupported message type #{msg.data.class.to_s}" )

--- a/logstash-input-jms.gemspec
+++ b/logstash-input-jms.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-jms'
-  s.version         = '3.2.1'
+  s.version         = '3.2.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from a Jms Broker"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
jruby-9.3.x removes support for `java_kind_of?` - this commit replaces it with `kind_of?`
