### PR TITLE
Support codecs generating multiple events

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -5,10 +5,17 @@ env
 
 set -ex
 
-export ACTIVEMQ_VERSION=5.15.15
+export ACTIVEMQ_VERSION=5.15.16
 ./setup_broker.sh
 bundle install
+
+java_major_version="$(JRUBY_OPTS="" jruby -e 'puts ENV_JAVA["java.version"]&.slice(/(?!1[.])[0-9]+/)')"
+if (( "${java_major_version}" >= "9" )); then
+  export JRUBY_OPTS="-J--add-exports=java.base/sun.security.ssl=ALL-UNNAMED${JRUBY_OPTS:+ }${JRUBY_OPTS}"
+fi
+
 bundle exec rspec
+
 ./start_ssl_broker.sh
 bundle exec rspec -fd --tag integration --tag tls --tag ~plaintext
 ./stop_broker.sh
@@ -16,4 +23,5 @@ bundle exec rspec -fd --tag integration --tag tls --tag ~plaintext
 ./start_broker.sh
 bundle exec rspec -fd --tag integration --tag plaintext --tag ~tls
 ./stop_broker.sh
+
 ./teardown_broker.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.0
+ - Added support for decoding multiple events from text or binary messages when using a codec that produces multiple events
+
 ## 3.2.2
  - Fix: Remove usage of `java_kind_of?` to allow this plugin to be supported for versions of Logstash using jruby-9.3.x
  [#54](https://github.com/logstash-plugins/logstash-input-jms/pull/54)

--- a/logstash-input-jms.gemspec
+++ b/logstash-input-jms.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-jms'
-  s.version         = '3.2.2'
+  s.version         = '3.3.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from a Jms Broker"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -32,5 +32,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "jruby-jms", ">= 1.2.0" #(Apache 2.0 license)
   s.add_runtime_dependency 'semantic_logger', '< 4.0.0'
 
+  s.add_development_dependency 'logstash-codec-line', '~> 3.0'
   s.add_development_dependency 'logstash-devutils'
 end

--- a/setup_broker.sh
+++ b/setup_broker.sh
@@ -9,6 +9,6 @@ fi
 
 curl -s -o activemq-all.jar https://repo1.maven.org/maven2/org/apache/activemq/activemq-all/$ACTIVEMQ_VERSION/activemq-all-$ACTIVEMQ_VERSION.jar
 mv activemq-all.jar ./spec/inputs/fixtures/
-curl -s -o activemq-bin.tar.gz http://archive.apache.org/dist/activemq/$ACTIVEMQ_VERSION/apache-activemq-$ACTIVEMQ_VERSION-bin.tar.gz
+curl -s -o activemq-bin.tar.gz https://archive.apache.org/dist/activemq/$ACTIVEMQ_VERSION/apache-activemq-$ACTIVEMQ_VERSION-bin.tar.gz
 tar xvf activemq-bin.tar.gz
 mv apache-activemq-$ACTIVEMQ_VERSION activemq

--- a/spec/inputs/integration/jms_spec.rb
+++ b/spec/inputs/integration/jms_spec.rb
@@ -241,6 +241,19 @@ shared_examples_for "a JMS input" do
 
         end
       end
+
+      context 'when using a multi-event codec' do
+        let(:config) { super().merge('codec' => 'line') }
+        let(:message) { 'one' + "\n" + 'two' + "\n" + 'three' }
+        it 'emits multiple events' do
+          send_message do |session|
+            session.message(message)
+          end
+          expect(queue.size).to eql 3
+          expect(queue.map { |e| e.get('message') }).to contain_exactly("one", "two", "three")
+          expect(queue).to all(have_header_value("jms_destination", destination))
+        end
+      end
     end
 
     context 'when the message is map message', :ecs_compatibility_support do

--- a/spec/inputs/unit/jms_spec.rb
+++ b/spec/inputs/unit/jms_spec.rb
@@ -291,7 +291,7 @@ describe LogStash::Inputs::Jms do
         allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility)
 
         plugin.register
-        plugin.queue_event(jms_message_double, queue = [])
+        plugin.queue_events(jms_message_double, queue = [])
         expect(queue.size).to eql 1
         @event = queue.first
       end


### PR DESCRIPTION
Adds support for codecs that produce multiple events (such as `line`, `json_lines`, etc.)