### PR TITLE
restoring call to decorate(event) for common options to work

### DIFF
--- a/lib/logstash/inputs/jms.rb
+++ b/lib/logstash/inputs/jms.rb
@@ -334,9 +334,9 @@ class LogStash::Inputs::Jms < LogStash::Inputs::Threadable
         @properties_setter.call(event, properties)
       end
 
+      decorate(event)
       event
     end.each do |ready_event|
-      decorate(event)
       output_queue << ready_event
     end
   end

--- a/lib/logstash/inputs/jms.rb
+++ b/lib/logstash/inputs/jms.rb
@@ -336,6 +336,7 @@ class LogStash::Inputs::Jms < LogStash::Inputs::Threadable
 
       event
     end.each do |ready_event|
+      decorate(event)
       output_queue << ready_event
     end
   end


### PR DESCRIPTION
In 3.3.0, the call to decorate(event) was removed, meaning "common options" such as add_field and tags were no longer applied to the event. This PR _tries_  to restore that functionality.


Where it was removed : https://github.com/logstash-plugins/logstash-input-jms/commit/4a1530f51d9ba99a11fe93b0ef1c672657c034c5#diff-2e09dad818d884b899bb96bc87f8149d81e57fa45aedf8251ce95fe73118445aL330

Code for the original function : https://github.com/elastic/logstash/blob/main/logstash-core/lib/logstash/inputs/base.rb#L135-L141


