### PR TITLE
Fixed a regression where `add_field` is no longer enriching events

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -5,7 +5,7 @@ env
 
 set -ex
 
-export ACTIVEMQ_VERSION=5.15.16
+export ACTIVEMQ_VERSION=5.19.0
 ./setup_broker.sh
 bundle install
 

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -5,7 +5,7 @@ env
 
 set -ex
 
-export ACTIVEMQ_VERSION=5.19.0
+export ACTIVEMQ_VERSION=5.15.16
 ./setup_broker.sh
 bundle install
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 3.3.1
+ - Fixed a regression introduced in 3.3.0 where `add_field` is no longer enriching events.
+
 ## 3.3.0
- - Added support for decoding multiple events from text or binary messages when using a codec that produces multiple events
+ - Added support for decoding multiple events from text or binary messages when using a codec that produces multiple events [#56](https://github.com/logstash-plugins/logstash-input-jms/pull/56)
 
 ## 3.2.2
  - Fix: Remove usage of `java_kind_of?` to allow this plugin to be supported for versions of Logstash using jruby-9.3.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.3.1
- - Fixed a regression introduced in 3.3.0 where `add_field` is no longer enriching events.
+ - Fixed a regression introduced in 3.3.0 where `add_field` is no longer enriching events [#59](https://github.com/logstash-plugins/logstash-input-jms/pull/59)
 
 ## 3.3.0
  - Added support for decoding multiple events from text or binary messages when using a codec that produces multiple events [#56](https://github.com/logstash-plugins/logstash-input-jms/pull/56)

--- a/lib/logstash/inputs/jms.rb
+++ b/lib/logstash/inputs/jms.rb
@@ -334,6 +334,7 @@ class LogStash::Inputs::Jms < LogStash::Inputs::Threadable
         @properties_setter.call(event, properties)
       end
 
+      decorate(event)
       event
     end.each do |ready_event|
       output_queue << ready_event

--- a/logstash-input-jms.gemspec
+++ b/logstash-input-jms.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-jms'
-  s.version         = '3.3.0'
+  s.version         = '3.3.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from a Jms Broker"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/setup_broker.sh
+++ b/setup_broker.sh
@@ -9,6 +9,6 @@ fi
 
 curl -s -o activemq-all.jar https://repo1.maven.org/maven2/org/apache/activemq/activemq-all/$ACTIVEMQ_VERSION/activemq-all-$ACTIVEMQ_VERSION.jar
 mv activemq-all.jar ./spec/inputs/fixtures/
-curl -s -o activemq-bin.tar.gz https://archive.apache.org/dist/activemq/$ACTIVEMQ_VERSION/apache-activemq-$ACTIVEMQ_VERSION-bin.tar.gz
+curl -s -o activemq-bin.tar.gz https://dlcdn.apache.org//activemq/$ACTIVEMQ_VERSION/apache-activemq-$ACTIVEMQ_VERSION-bin.tar.gz
 tar xvf activemq-bin.tar.gz
 mv apache-activemq-$ACTIVEMQ_VERSION activemq

--- a/setup_broker.sh
+++ b/setup_broker.sh
@@ -9,6 +9,6 @@ fi
 
 curl -s -o activemq-all.jar https://repo1.maven.org/maven2/org/apache/activemq/activemq-all/$ACTIVEMQ_VERSION/activemq-all-$ACTIVEMQ_VERSION.jar
 mv activemq-all.jar ./spec/inputs/fixtures/
-curl -s -o activemq-bin.tar.gz https://dlcdn.apache.org//activemq/$ACTIVEMQ_VERSION/apache-activemq-$ACTIVEMQ_VERSION-bin.tar.gz
+curl -s -o activemq-bin.tar.gz https://repo1.maven.org/maven2/org/apache/activemq/apache-activemq/$ACTIVEMQ_VERSION/apache-activemq-$ACTIVEMQ_VERSION-bin.tar.gz
 tar xvf activemq-bin.tar.gz
 mv apache-activemq-$ACTIVEMQ_VERSION activemq


### PR DESCRIPTION
Add back the `decorate(event)` to allow `add_field` enriching event

https://github.com/logstash-plugins/logstash-input-jms/issues/58
